### PR TITLE
Use React.createElement for orientation renders

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -4,29 +4,30 @@ import { Orientation1ere } from "./components/orientation/Orientation1ere.js";
 import { OrientationTerminale } from "./components/orientation/OrientationTerminale.js";
 
 const { createRoot } = ReactDOM;
+const { createElement } = React;
 
 document.addEventListener("DOMContentLoaded", () => {
   const rootElement = document.getElementById("film-annuel-root");
   if (rootElement) {
     const root = createRoot(rootElement);
-    root.render(<Orientation3e />);
+    root.render(createElement(Orientation3e));
   }
 
   const root2ndeElement = document.getElementById("film-annuel-2nde-root");
   if (root2ndeElement) {
     const root = createRoot(root2ndeElement);
-    root.render(<Orientation2nde />);
+    root.render(createElement(Orientation2nde));
   }
 
   const root1ereElement = document.getElementById("film-annuel-1ere-root");
   if (root1ereElement) {
     const root = createRoot(root1ereElement);
-    root.render(<Orientation1ere />);
+    root.render(createElement(Orientation1ere));
   }
 
   const rootTerminaleElement = document.getElementById("film-annuel-terminale-root");
   if (rootTerminaleElement) {
     const root = createRoot(rootTerminaleElement);
-    root.render(<OrientationTerminale />);
+    root.render(createElement(OrientationTerminale));
   }
 });


### PR DESCRIPTION
## Summary
- import React.createElement alongside ReactDOM.createRoot
- render orientation components using createElement instead of JSX

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd392a4ea48331b0a11b33db371ba8