### PR TITLE
Ajoute les informations de contact de la PRIO

### DIFF
--- a/INDEX.html
+++ b/INDEX.html
@@ -167,8 +167,22 @@
             <aside class="space-y-6 rounded-3xl border border-slate-200 bg-white/80 p-6 shadow-sm">
               <h2 class="text-base font-semibold text-slate-900">Points de contact</h2>
               <ul class="space-y-4 text-sm text-slate-600">
-                <li>
-                  <span class="block font-semibold text-slate-800">PRIO</span>
+                <li class="space-y-3">
+                  <div class="flex items-center gap-3">
+                    <div
+                      class="h-16 w-16 shrink-0 overflow-hidden rounded-full border border-slate-200 bg-slate-100"
+                      role="img"
+                      aria-label="Portrait de la PRIO"
+                      style="background-image: url('https://i.imgur.com/7VjSMiU.png'); background-size: cover; background-position: center; pointer-events: none;"
+                    ></div>
+                    <div>
+                      <span class="block font-semibold text-slate-800">PRIO</span>
+                      <a
+                        href="mailto:orientation@lfjpsaly.org"
+                        class="text-sky-600 hover:text-sky-700"
+                      >orientation@lfjpsaly.org</a>
+                    </div>
+                  </div>
                   <span>Accompagnement individuel, bilans, mini-stages.</span>
                 </li>
                 <li>


### PR DESCRIPTION
## Résumé
- affiche le portrait de la PRIO directement dans la carte des points de contact
- ajoute l’adresse orientation@lfjpsaly.org pour faciliter la prise de rendez-vous
- empêche l’enregistrement direct de la photo en l’utilisant comme image d’arrière-plan

## Tests
- aucun test automatisé disponible

------
https://chatgpt.com/codex/tasks/task_e_68dd521a72788331b52f309dac31b6cd