### PR TITLE
Improve text normalization and rebuild bundle

### DIFF
--- a/scripts/app.bundle.js
+++ b/scripts/app.bundle.js
@@ -238,7 +238,7 @@
     return values.filter(Boolean).join(" ");
   }
   function normalizeText(value) {
-    return (value || "").toLowerCase().normalize("NFD").replace(new RegExp("\\p{Diacritic}", "gu"), "");
+    return (value || "").replace(/[\u00A0\u202F]/g, " ").replace(/[\u2010-\u2015]/g, "-").replace(/[\u2018\u2019\u201B]/g, "'").replace(/[\u201C\u201D]/g, '"').replace(/-/g, " ").replace(/\s{2,}/g, " ").toLowerCase().normalize("NFD").replace(/\p{Diacritic}/gu, "").trim();
   }
 
   // scripts/components/orientation/Timeline3e.js
@@ -250,7 +250,7 @@
         {
           className: classNames(
             "rounded-2xl border p-5 shadow-sm transition hover:shadow-md",
-            phaseMeta == null ? void 0 : phaseMeta.color
+            phaseMeta?.color
           )
         },
         /* @__PURE__ */ React.createElement("div", { className: "flex flex-wrap items-baseline justify-between gap-2" }, /* @__PURE__ */ React.createElement("h4", { className: "font-semibold text-slate-900" }, item.titre), /* @__PURE__ */ React.createElement("span", { className: "text-xs font-semibold uppercase tracking-wide text-slate-700" }, item.periode)),
@@ -292,8 +292,7 @@
         map.get(item.phase).push(item);
       }
       return Array.from(map.entries()).sort((a, b) => {
-        var _a, _b;
-        return ((_a = phaseIndex.get(a[0])) != null ? _a : 0) - ((_b = phaseIndex.get(b[0])) != null ? _b : 0);
+        return (phaseIndex.get(a[0]) ?? 0) - (phaseIndex.get(b[0]) ?? 0);
       });
     }, [filtered, phases]);
     return {
@@ -557,7 +556,7 @@
   function Timeline2nde({ grouped, phases }) {
     return /* @__PURE__ */ React.createElement("div", { className: "flex flex-col gap-8" }, grouped.map(([title, items]) => {
       const phaseMeta = phases.find((phase) => phase.key === title);
-      return /* @__PURE__ */ React.createElement("section", { key: title }, /* @__PURE__ */ React.createElement("h2", { className: "mb-3 text-lg font-semibold" }, title), /* @__PURE__ */ React.createElement("div", { className: "relative pl-6" }, /* @__PURE__ */ React.createElement("div", { className: "absolute left-2 top-0 h-full w-px bg-slate-200", "aria-hidden": true }), /* @__PURE__ */ React.createElement("ul", { className: "space-y-4" }, items.map((item) => /* @__PURE__ */ React.createElement("li", { key: item.id, className: "relative" }, /* @__PURE__ */ React.createElement("div", { className: "absolute -left-1.5 top-2 h-3 w-3 rounded-full bg-white ring-2 ring-slate-300", "aria-hidden": true }), /* @__PURE__ */ React.createElement("article", { className: classNames("rounded-2xl border p-4", phaseMeta == null ? void 0 : phaseMeta.color) }, /* @__PURE__ */ React.createElement("div", { className: "flex flex-wrap items-baseline justify-between gap-2" }, /* @__PURE__ */ React.createElement("h3", { className: "font-medium" }, item.titre), /* @__PURE__ */ React.createElement("span", { className: "text-xs text-slate-700" }, item.periode)), /* @__PURE__ */ React.createElement("p", { className: "mt-1 text-sm text-slate-700" }, item.details), /* @__PURE__ */ React.createElement("div", { className: "mt-2 flex flex-wrap gap-2 text-xs text-slate-600" }, /* @__PURE__ */ React.createElement(Badge, { icon: "users", label: item.acteurs.join(", ") }), /* @__PURE__ */ React.createElement(Badge, { icon: "map-pin", label: item.lieu }), /* @__PURE__ */ React.createElement(Badge, { icon: "flag", label: item.phase }))))))));
+      return /* @__PURE__ */ React.createElement("section", { key: title }, /* @__PURE__ */ React.createElement("h2", { className: "mb-3 text-lg font-semibold" }, title), /* @__PURE__ */ React.createElement("div", { className: "relative pl-6" }, /* @__PURE__ */ React.createElement("div", { className: "absolute left-2 top-0 h-full w-px bg-slate-200", "aria-hidden": true }), /* @__PURE__ */ React.createElement("ul", { className: "space-y-4" }, items.map((item) => /* @__PURE__ */ React.createElement("li", { key: item.id, className: "relative" }, /* @__PURE__ */ React.createElement("div", { className: "absolute -left-1.5 top-2 h-3 w-3 rounded-full bg-white ring-2 ring-slate-300", "aria-hidden": true }), /* @__PURE__ */ React.createElement("article", { className: classNames("rounded-2xl border p-4", phaseMeta?.color) }, /* @__PURE__ */ React.createElement("div", { className: "flex flex-wrap items-baseline justify-between gap-2" }, /* @__PURE__ */ React.createElement("h3", { className: "font-medium" }, item.titre), /* @__PURE__ */ React.createElement("span", { className: "text-xs text-slate-700" }, item.periode)), /* @__PURE__ */ React.createElement("p", { className: "mt-1 text-sm text-slate-700" }, item.details), /* @__PURE__ */ React.createElement("div", { className: "mt-2 flex flex-wrap gap-2 text-xs text-slate-600" }, /* @__PURE__ */ React.createElement(Badge, { icon: "users", label: item.acteurs.join(", ") }), /* @__PURE__ */ React.createElement(Badge, { icon: "map-pin", label: item.lieu }), /* @__PURE__ */ React.createElement(Badge, { icon: "flag", label: item.phase }))))))));
     }));
   }
 
@@ -759,7 +758,7 @@
   function Timeline1ere({ grouped, phases }) {
     return /* @__PURE__ */ React.createElement("div", { className: "flex flex-col gap-8" }, grouped.map(([title, items]) => {
       const phaseMeta = phases.find((phase) => phase.key === title);
-      return /* @__PURE__ */ React.createElement("section", { key: title }, /* @__PURE__ */ React.createElement("h2", { className: "mb-3 text-lg font-semibold" }, title), /* @__PURE__ */ React.createElement("div", { className: "relative pl-6" }, /* @__PURE__ */ React.createElement("div", { className: "absolute left-2 top-0 h-full w-px bg-slate-200", "aria-hidden": true }), /* @__PURE__ */ React.createElement("ul", { className: "space-y-4" }, items.map((item) => /* @__PURE__ */ React.createElement("li", { key: item.id, className: "relative" }, /* @__PURE__ */ React.createElement("div", { className: "absolute -left-1.5 top-2 h-3 w-3 rounded-full bg-white ring-2 ring-slate-300", "aria-hidden": true }), /* @__PURE__ */ React.createElement("article", { className: classNames("rounded-2xl border p-4", phaseMeta == null ? void 0 : phaseMeta.color) }, /* @__PURE__ */ React.createElement("div", { className: "flex flex-wrap items-baseline justify-between gap-2" }, /* @__PURE__ */ React.createElement("h3", { className: "font-medium" }, item.titre), /* @__PURE__ */ React.createElement("span", { className: "text-xs text-slate-700" }, item.periode)), /* @__PURE__ */ React.createElement("p", { className: "mt-1 text-sm text-slate-700" }, item.details), /* @__PURE__ */ React.createElement("div", { className: "mt-2 flex flex-wrap gap-2 text-xs text-slate-600" }, /* @__PURE__ */ React.createElement(Badge, { icon: "users", label: item.acteurs.join(", ") }), /* @__PURE__ */ React.createElement(Badge, { icon: "map-pin", label: item.lieu }), /* @__PURE__ */ React.createElement(Badge, { icon: "flag", label: item.phase }))))))));
+      return /* @__PURE__ */ React.createElement("section", { key: title }, /* @__PURE__ */ React.createElement("h2", { className: "mb-3 text-lg font-semibold" }, title), /* @__PURE__ */ React.createElement("div", { className: "relative pl-6" }, /* @__PURE__ */ React.createElement("div", { className: "absolute left-2 top-0 h-full w-px bg-slate-200", "aria-hidden": true }), /* @__PURE__ */ React.createElement("ul", { className: "space-y-4" }, items.map((item) => /* @__PURE__ */ React.createElement("li", { key: item.id, className: "relative" }, /* @__PURE__ */ React.createElement("div", { className: "absolute -left-1.5 top-2 h-3 w-3 rounded-full bg-white ring-2 ring-slate-300", "aria-hidden": true }), /* @__PURE__ */ React.createElement("article", { className: classNames("rounded-2xl border p-4", phaseMeta?.color) }, /* @__PURE__ */ React.createElement("div", { className: "flex flex-wrap items-baseline justify-between gap-2" }, /* @__PURE__ */ React.createElement("h3", { className: "font-medium" }, item.titre), /* @__PURE__ */ React.createElement("span", { className: "text-xs text-slate-700" }, item.periode)), /* @__PURE__ */ React.createElement("p", { className: "mt-1 text-sm text-slate-700" }, item.details), /* @__PURE__ */ React.createElement("div", { className: "mt-2 flex flex-wrap gap-2 text-xs text-slate-600" }, /* @__PURE__ */ React.createElement(Badge, { icon: "users", label: item.acteurs.join(", ") }), /* @__PURE__ */ React.createElement(Badge, { icon: "map-pin", label: item.lieu }), /* @__PURE__ */ React.createElement(Badge, { icon: "flag", label: item.phase }))))))));
     }));
   }
 
@@ -994,7 +993,7 @@
           className: "absolute -left-1.5 top-2 h-3 w-3 rounded-full bg-white ring-2 ring-slate-300",
           "aria-hidden": true
         }
-      ), /* @__PURE__ */ React.createElement("article", { className: classNames("rounded-2xl border p-4", phaseMeta == null ? void 0 : phaseMeta.color) }, /* @__PURE__ */ React.createElement("div", { className: "flex flex-wrap items-baseline justify-between gap-2" }, /* @__PURE__ */ React.createElement("h3", { className: "font-medium" }, item.titre), /* @__PURE__ */ React.createElement("span", { className: "text-xs text-slate-700" }, item.periode)), /* @__PURE__ */ React.createElement("p", { className: "mt-1 text-sm text-slate-700" }, item.details), /* @__PURE__ */ React.createElement("div", { className: "mt-2 flex flex-wrap gap-2 text-xs text-slate-600" }, /* @__PURE__ */ React.createElement(Badge, { icon: "users", label: item.acteurs.join(", ") }), /* @__PURE__ */ React.createElement(Badge, { icon: "map-pin", label: item.lieu }), /* @__PURE__ */ React.createElement(Badge, { icon: "flag", label: item.phase }))))))));
+      ), /* @__PURE__ */ React.createElement("article", { className: classNames("rounded-2xl border p-4", phaseMeta?.color) }, /* @__PURE__ */ React.createElement("div", { className: "flex flex-wrap items-baseline justify-between gap-2" }, /* @__PURE__ */ React.createElement("h3", { className: "font-medium" }, item.titre), /* @__PURE__ */ React.createElement("span", { className: "text-xs text-slate-700" }, item.periode)), /* @__PURE__ */ React.createElement("p", { className: "mt-1 text-sm text-slate-700" }, item.details), /* @__PURE__ */ React.createElement("div", { className: "mt-2 flex flex-wrap gap-2 text-xs text-slate-600" }, /* @__PURE__ */ React.createElement(Badge, { icon: "users", label: item.acteurs.join(", ") }), /* @__PURE__ */ React.createElement(Badge, { icon: "map-pin", label: item.lieu }), /* @__PURE__ */ React.createElement(Badge, { icon: "flag", label: item.phase }))))))));
     }));
   }
 

--- a/scripts/utils/stringUtils.js
+++ b/scripts/utils/stringUtils.js
@@ -4,7 +4,14 @@ export function classNames(...values) {
 
 export function normalizeText(value) {
   return (value || "")
+    .replace(/[\u00A0\u202F]/g, " ")
+    .replace(/[\u2010-\u2015]/g, "-")
+    .replace(/[\u2018\u2019\u201B]/g, "'")
+    .replace(/[\u201C\u201D]/g, '"')
+    .replace(/-/g, " ")
+    .replace(/\s{2,}/g, " ")
     .toLowerCase()
     .normalize("NFD")
-    .replace(/\p{Diacritic}/gu, "");
+    .replace(/\p{Diacritic}/gu, "")
+    .trim();
 }


### PR DESCRIPTION
## Summary
- extend the normalizeText helper to replace typographic dashes, apostrophes, quotes, and non-breaking spaces with ASCII equivalents, collapse spacing, and trim results before diacritic stripping
- rebuild the distributed app bundle so the packaged site includes the updated normalization logic

## Testing
- node --input-type=module <<'NODE'
import { normalizeText } from './scripts/utils/stringUtils.js';
import { DATA_1ERE } from './scripts/data/filmAnnuel1ere.js';
import { DATA_TERMINALE } from './scripts/data/filmAnnuelTerminale.js';

function search(dataset, query) {
  const normalizedQuery = normalizeText(query);
  return dataset
    .filter((entry) => {
      const haystack = [
        entry.titre,
        entry.details,
        entry.periode,
        Array.isArray(entry.acteurs) ? entry.acteurs.join(' ') : entry.acteurs,
      ]
        .map(normalizeText)
        .join(' ');
      return haystack.includes(normalizedQuery);
    })
    .map((entry) => entry.titre);
}

console.log('1ere post-bac:', search(DATA_1ERE, 'post-bac'));
console.log('1ere post bac:', search(DATA_1ERE, 'post bac'));
console.log("1ere l'etranger:", search(DATA_1ERE, "l'etranger"));
console.log('Term post bac:', search(DATA_TERMINALE, 'post bac'));
NODE


------
https://chatgpt.com/codex/tasks/task_e_68dd88bd17f88331ad1996cbdb44aecb