### PR TITLE
Redesign orientation banner to highlight class

### DIFF
--- a/scripts/components/orientation/Orientation3e.js
+++ b/scripts/components/orientation/Orientation3e.js
@@ -21,63 +21,65 @@ export function Orientation3e() {
 
   return (
     <div className="mx-auto max-w-7xl space-y-6 p-6">
-      <header className="overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-sm">
-        <div className="bg-gradient-to-r from-indigo-50 via-white to-sky-50 px-6 py-6">
-          <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
-            <div className="flex flex-col gap-5">
-              <div className="flex flex-wrap items-center gap-4 sm:gap-6">
-                <img
-                  src="https://i.imgur.com/0YmGlXO.png"
-                  alt="Logo du Lycée Français Jacques Prévert de Saly"
-                  className="h-14 w-auto"
-                  loading="lazy"
-                  width="96"
-                  height="96"
-                />
-                <span className="hidden h-14 w-px bg-gradient-to-b from-transparent via-indigo-200 to-transparent sm:block" />
-                <div className="flex items-center gap-4">
-                  <span className="flex h-16 w-16 items-center justify-center rounded-2xl bg-indigo-500 text-3xl font-bold text-white shadow-lg shadow-indigo-200">
-                    3e
-                  </span>
-                  <div className="space-y-1">
-                    <p className="text-xs font-semibold uppercase tracking-widest text-indigo-600">Film annuel de l'orientation</p>
-                    <h3 className="text-3xl font-bold text-slate-900 sm:text-4xl">Classe de 3e</h3>
-                    <p className="text-sm text-slate-600">LFJP · Parcours Avenir · Année scolaire 2025‑2026</p>
-                  </div>
-                </div>
-              </div>
-              <div className="grid gap-3 text-sm sm:grid-cols-2">
-                <div className="flex items-center gap-3 rounded-2xl bg-white/80 px-4 py-3 shadow-sm backdrop-blur">
-                  <span className="flex h-10 w-10 items-center justify-center rounded-xl bg-indigo-100 text-indigo-600">
-                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-5 w-5">
-                      <path d="M11 3a1 1 0 0 0-2 0v1.382a3 3 0 0 0-1.447.829l-.978-.326a1 1 0 1 0-.632 1.898l.978.326a3.001 3.001 0 0 0 0 1.782l-.978.326a1 1 0 1 0 .632 1.898l.978-.326A3 3 0 0 0 9 11.618V13a1 1 0 1 0 2 0v-1.382a3 3 0 0 0 1.447-.829l.978.326a1 1 0 1 0 .632-1.898l-.978-.326a3 3 0 0 0 0-1.782l.978-.326a1 1 0 0 0-.632-1.898l-.978.326A3 3 0 0 0 11 4.382V3Z" />
-                    </svg>
-                  </span>
-                  <div>
-                    <p className="text-xs font-medium uppercase tracking-wide text-slate-500">Phases</p>
-                    <p className="text-lg font-semibold text-slate-900">{phasesCount}</p>
-                  </div>
-                </div>
-                <div className="flex items-center gap-3 rounded-2xl bg-white/80 px-4 py-3 shadow-sm backdrop-blur">
-                  <span className="flex h-10 w-10 items-center justify-center rounded-xl bg-sky-100 text-sky-600">
-                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-5 w-5">
-                      <path d="M4 5a2 2 0 0 1 2-2h1.5a.5.5 0 0 1 .4.2l1.1 1.6h5a2 2 0 0 1 2 2v1H4V5Z" />
-                      <path d="M4 9h12v6a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V9Z" />
-                    </svg>
-                  </span>
-                  <div>
-                    <p className="text-xs font-medium uppercase tracking-wide text-slate-500">Actions planifiées</p>
-                    <p className="text-lg font-semibold text-slate-900">{totalActions}</p>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div className="max-w-md rounded-2xl border border-white/60 bg-white/80 px-5 py-4 text-sm text-slate-600 shadow-sm backdrop-blur">
-              <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Objectif</p>
-              <p className="mt-1 leading-relaxed text-slate-700">
-                Naviguez parmi les actions clés pour préparer l'orientation des élèves de troisième tout au long de l'année.
+      <header className="relative overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-sm">
+        <div className="absolute inset-0 bg-gradient-to-br from-indigo-600 via-indigo-500 to-sky-500" />
+        <div className="absolute inset-y-0 -right-24 h-[140%] w-72 rotate-12 bg-white/20 blur-3xl" />
+        <div className="relative grid gap-8 px-8 py-10 text-white lg:grid-cols-[minmax(0,1.2fr)_minmax(0,0.8fr)] lg:items-center">
+          <div className="flex flex-col gap-8">
+            <div className="flex flex-wrap items-center gap-4 text-white/90 sm:gap-6">
+              <img
+                src="https://i.imgur.com/0YmGlXO.png"
+                alt="Logo du Lycée Français Jacques Prévert de Saly"
+                className="h-14 w-auto rounded-2xl bg-white/10 p-2 shadow-lg shadow-indigo-900/40"
+                loading="lazy"
+                width="96"
+                height="96"
+              />
+              <span className="hidden h-14 w-px bg-gradient-to-b from-transparent via-white/60 to-transparent sm:block" />
+              <p className="text-sm font-medium uppercase tracking-[0.4em] text-white/70">
+                Film annuel de l'orientation
               </p>
             </div>
+            <div className="rounded-3xl border border-white/20 bg-white/15 p-6 shadow-xl backdrop-blur">
+              <div className="flex flex-wrap items-baseline gap-x-4 gap-y-2">
+                <span className="text-xs font-semibold uppercase tracking-[0.5em] text-white/60">Classe de</span>
+                <span className="text-5xl font-black leading-none tracking-tight text-white drop-shadow-lg sm:text-6xl">3e</span>
+              </div>
+              <p className="mt-4 text-base font-medium text-white/90">
+                LFJP · Parcours Avenir · Année scolaire 2025‑2026
+              </p>
+            </div>
+            <div className="grid gap-4 text-sm sm:grid-cols-2">
+              <div className="flex items-center gap-3 rounded-2xl border border-white/10 bg-white/15 px-4 py-3 shadow-lg shadow-indigo-900/40 backdrop-blur">
+                <span className="flex h-12 w-12 items-center justify-center rounded-xl bg-white/20 text-white">
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-5 w-5">
+                    <path d="M11 3a1 1 0 0 0-2 0v1.382a3 3 0 0 0-1.447.829l-.978-.326a1 1 0 1 0-.632 1.898l.978.326a3.001 3.001 0 0 0 0 1.782l-.978.326a1 1 0 1 0 .632 1.898l.978-.326A3 3 0 0 0 9 11.618V13a1 1 0 1 0 2 0v-1.382a3 3 0 0 0 1.447-.829l.978.326a1 1 0 1 0 .632-1.898l-.978-.326a3 3 0 0 0 0-1.782l.978-.326a1 1 0 0 0-.632-1.898l-.978.326A3 3 0 0 0 11 4.382V3Z" />
+                  </svg>
+                </span>
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-wide text-white/70">Phases</p>
+                  <p className="text-lg font-semibold text-white">{phasesCount}</p>
+                </div>
+              </div>
+              <div className="flex items-center gap-3 rounded-2xl border border-white/10 bg-white/15 px-4 py-3 shadow-lg shadow-indigo-900/40 backdrop-blur">
+                <span className="flex h-12 w-12 items-center justify-center rounded-xl bg-white/20 text-white">
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-5 w-5">
+                    <path d="M4 5a2 2 0 0 1 2-2h1.5a.5.5 0 0 1 .4.2l1.1 1.6h5a2 2 0 0 1 2 2v1H4V5Z" />
+                    <path d="M4 9h12v6a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V9Z" />
+                  </svg>
+                </span>
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-wide text-white/70">Actions planifiées</p>
+                  <p className="text-lg font-semibold text-white">{totalActions}</p>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div className="max-w-lg rounded-3xl border border-white/20 bg-white/15 p-6 text-sm text-white shadow-xl backdrop-blur">
+            <p className="text-xs font-semibold uppercase tracking-wide text-white/70">Objectif</p>
+            <p className="mt-3 text-base leading-relaxed text-white/90">
+              Naviguez parmi les actions clés pour préparer l'orientation des élèves de troisième tout au long de l'année.
+            </p>
           </div>
         </div>
         <div className="border-t border-slate-100 bg-white px-6 py-4">


### PR DESCRIPTION
## Summary
- redesign the orientation header with a bold gradient hero section centred on the classe de 3e
- refresh statistics and objective cards with translucent glassmorphism styling to improve contrast

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de42ce3728833194658841a87fc5f9